### PR TITLE
Forbid duplicate keys

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest
       run: |
-        python3 -m pytest tests/test-schema.py -v
+        python3 -m pytest tests/test-*.py -vv
 
   lint:
 

--- a/Readme.md
+++ b/Readme.md
@@ -53,3 +53,18 @@ shall be added using the old API at this point.
 
 So as long as PyYAML doesn't merge this, you can use this module as an
 alternative.
+
+## Differences
+
+There are other differences in behaviour to PyYAML.
+
+### Duplicate keys are not allowed
+
+The YAML spec forbids duplicate keys. PyYAML allows them, which leads to
+accidentally added duplicate keys in YAML files, eventually.
+
+I can't see a good use case that people would want to allow duplicate
+keys in a typical YAML loading process.
+For the use cases I see you would want your own constructor anyway.
+
+If this is breaking anyone's use case, please let me know.

--- a/tests/test-yaml.py
+++ b/tests/test-yaml.py
@@ -1,0 +1,21 @@
+import yaml
+import unittest
+
+from yamlcore import CoreLoader
+
+class TestVariousFeatures(unittest.TestCase):
+
+    def test_duplicate_keys(self):
+        input = """
+        a: 1
+        a: 2
+        """
+        data = None
+        msg = None
+        try:
+            data = yaml.load(input, Loader=CoreLoader)
+        except yaml.YAMLError as e:
+            msg = str(e)
+        assert(data == None)
+        self.assertRegex(msg, r'found duplicate key')
+

--- a/yamlcore/loader.py
+++ b/yamlcore/loader.py
@@ -1,5 +1,6 @@
 import yaml
 import re
+import collections.abc
 
 
 class CommonResolver(yaml.resolver.BaseResolver):
@@ -80,6 +81,26 @@ class CommonConstructor(yaml.constructor.BaseConstructor):
             return self.nan_value
         else:
             return sign*float(value)
+
+    def construct_mapping(self, node, deep=False):
+        if not isinstance(node, yaml.MappingNode):
+            raise yaml.constructor.ConstructorError(None, None,
+                    "expected a mapping node, but found %s" % node.id,
+                    node.start_mark)
+        mapping = {}
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            if not isinstance(key, collections.abc.Hashable):
+                raise yaml.constructor.ConstructorError("while constructing a mapping", node.start_mark,
+                        "found unhashable key", key_node.start_mark)
+            value = self.construct_object(value_node, deep=deep)
+            if key in mapping:
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping", node.start_mark,
+                    "found duplicate key", key_node.start_mark
+                )
+            mapping[key] = value
+        return mapping
 
     @classmethod
     def init_constructors(cls, tagset):


### PR DESCRIPTION
The YAML specification says: YAML mappings require key uniqueness

PyYAML allows duplicate mapping keys, it just overwrites previous ones. Because it is tightly coupled with the implementation of merge keys, it isn't trivial to do the same change in PyYAML in a backwards compatible way.

There is no way to optionally allow duplicate keys, but if PyYAML gets this feature to allow/disallow, I will add it here as well.

This might be a breaking change, but I believe forbidding duplicate keys has more advantages than disadvantages.