### PR TITLE
Add PyYAML dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,3 +22,5 @@ package_dir =
 packages = yamlcore
 python_requires = >=3.6
 
+install_requires =
+    PyYAML


### PR DESCRIPTION
Apparently the tool that builds the release tarball isn't able to read the requirements.txt, so I have now two places where I have to specify the dependencies.

Can I just remove requirements.txt? No idea.